### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -1,5 +1,8 @@
 name: Code quality checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/complexitty/security/code-scanning/1](https://github.com/davep/complexitty/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes for this workflow. Since this workflow just checks out the repo and runs local quality checks, it only needs to read repository contents. The recommended minimal starting point from CodeQL is `contents: read`, which is sufficient for `actions/checkout` and does not grant any write access.

The best targeted fix without changing existing functionality is to add a `permissions:` block at the workflow root (alongside `name:` and `on:`). That will apply to all jobs (currently only `quality-checks`) that don’t declare their own permissions. Concretely, in `.github/workflows/code-checks.yaml`, between the existing `name: Code quality checks` (line 1) and the `on:` block (line 3), insert:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
